### PR TITLE
remove malloc.h include

### DIFF
--- a/ttf2mesh.c
+++ b/ttf2mesh.c
@@ -51,7 +51,6 @@
 
 #include "ttf2mesh.h"
 #include <string.h>
-#include <malloc.h>
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
I'm not a C/C++ developer, but I was trying to use a Rust wrapper for this library (https://github.com/blaind/ttf2mesh-rs) and when I switched from my Ubuntu instance to my M1 Mac I was getting build failures:

```
  cargo:warning=ttf2mesh/ttf2mesh.c:54:10: fatal error: 'malloc.h' file not found
  cargo:warning=#include <malloc.h>
```

A quick google said that `malloc.h` is deprecated and the (already present) `stdlib.h` has what's needed. 

https://stackoverflow.com/questions/12973311/difference-between-stdlib-h-and-malloc-h