### PR TITLE
perform exact equality check on circumcircles to avoid ping-ponging between two good candidates

### DIFF
--- a/ttf2mesh.c
+++ b/ttf2mesh.c
@@ -3313,7 +3313,7 @@ int optimize(mesher_t *m, mes_t *e, int deep)
         return MESHER_DONE;
 
     if (done1 && done2)
-        if (e->alt_cc[0].radius + e->alt_cc[1].radius + EPSILON > e->tr[0]->cc.radius + e->tr[1]->cc.radius)
+        if (e->alt_cc[0].radius + e->alt_cc[1].radius >= e->tr[0]->cc.radius + e->tr[1]->cc.radius)
             return MESHER_DONE;
 
     int res = flip_edge(m, e);


### PR DESCRIPTION
Hey there, thanks for this project! I've been studying the code to learn from it, particularly the mesher/triangulation code. I fed the mesher a circular shape and noticed the algorithm can spend a lot of time in the `optimize` step (if `deep` is large enough).

These are the exact points I fed the mesher:

```
[351.22815, -12.458579],
[311.03577, 164.45859],
[187.76953, 297.5772],
[14.458568, 351.22815],
[-162.4586, 311.03577],
[-295.57718, 187.76956],
[-349.22815, 14.458562],
[-309.03577, -162.45859],
[-185.76953, -295.5772],
[-12.45858, -349.22815],
[164.45856, -309.0358],
[297.57724, -185.76947],
```

![Screen Shot 2023-03-04 at 5 55 03 PM](https://user-images.githubusercontent.com/46233424/222934298-81c65dd9-de2b-4942-8397-6784fc32af42.png)


It seems to me that the `optimize` step finds that both pairs of candidate circumcircles are nearly identical, and in this case, will ping-pong between them unnecessarily. You can see my code changes for what I believe is the exact cause of this. I'm not sure why the code originally had some tolerance. It seems unnecessary.